### PR TITLE
Remove shared preferences migration

### DIFF
--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -80,7 +80,6 @@ dependencies {
 
     implementation("androidx.core:core-ktx:1.9.0")
     implementation("androidx.datastore:datastore-preferences:1.0.0")
-    implementation("androidx.preference:preference-ktx:1.2.0")
     implementation("io.insert-koin:koin-android:3.2.1")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutinesVersion")
     implementation("androidx.room:room-runtime:$roomVersion")

--- a/data/src/main/kotlin/io/github/fobo66/data/di/DataModule.kt
+++ b/data/src/main/kotlin/io/github/fobo66/data/di/DataModule.kt
@@ -2,10 +2,8 @@ package io.github.fobo66.data.di
 
 import android.content.Context
 import androidx.datastore.core.DataStore
-import androidx.datastore.preferences.SharedPreferencesMigration
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.preferencesDataStore
-import androidx.preference.PreferenceManager
 import de.jensklingenberg.ktorfit.Ktorfit
 import de.jensklingenberg.ktorfit.create
 import io.github.fobo66.data.API_BASE_URL
@@ -83,12 +81,5 @@ val dataModule = module {
 }
 
 private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(
-    name = "wearmmr",
-    produceMigrations = { context ->
-        listOf(
-            SharedPreferencesMigration(produceSharedPreferences = {
-                PreferenceManager.getDefaultSharedPreferences(context)
-            })
-        )
-    }
+    name = "wearmmr"
 )


### PR DESCRIPTION
After release with new datastore, we can remove migration from shared prefs once all users are on the new version